### PR TITLE
crypto_aead: fix usage faults in `armv7m*`

### DIFF
--- a/crypto_aead/ascon128av12/armv7m/word.h
+++ b/crypto_aead/ascon128av12/armv7m/word.h
@@ -45,16 +45,6 @@ forceinline uint64_t MASK(int n) {
   return ~0ull >> (64 - 8 * n);
 }
 
-forceinline uint64_t LOAD(const uint8_t* bytes, int n) {
-  uint64_t x = *(uint64_t*)bytes & MASK(n);
-  return U64TOWORD(x);
-}
-
-forceinline void STORE(uint8_t* bytes, uint64_t w, int n) {
-  *(uint64_t*)bytes &= ~MASK(n);
-  *(uint64_t*)bytes |= WORDTOU64(w);
-}
-
 forceinline uint64_t LOADBYTES(const uint8_t* bytes, int n) {
   uint64_t x = 0;
   memcpy(&x, bytes, n);
@@ -64,6 +54,14 @@ forceinline uint64_t LOADBYTES(const uint8_t* bytes, int n) {
 forceinline void STOREBYTES(uint8_t* bytes, uint64_t w, int n) {
   uint64_t x = WORDTOU64(w);
   memcpy(bytes, &x, n);
+}
+
+forceinline uint64_t LOAD(const uint8_t* bytes, int n) {
+  return LOADBYTES(bytes, n);
+}
+
+forceinline void STORE(uint8_t* bytes, uint64_t w, int n) {
+  STOREBYTES(bytes, w, n);
 }
 
 #endif /* WORD_H_ */

--- a/crypto_aead/ascon128av12/armv7m_lowsize/aead.c
+++ b/crypto_aead/ascon128av12/armv7m_lowsize/aead.c
@@ -98,8 +98,9 @@ void ascon_aead(uint8_t* t, uint8_t* out, const uint8_t* in, uint64_t tlen,
   if (mode == ASCON_DECRYPT) printstate("pad ciphertext", &s);
   /* finalize */
   ascon_final(&s, &key);
-  ((uint64_t*)t)[0] = WORDTOU64(s.x[3]);
-  ((uint64_t*)t)[1] = WORDTOU64(s.x[4]);
+  /* set tag */
+  STOREBYTES(t, s.x[3], 8);
+  STOREBYTES(t + 8, s.x[4], 8);
 }
 
 #endif

--- a/crypto_aead/ascon128av12/armv7m_lowsize/word.h
+++ b/crypto_aead/ascon128av12/armv7m_lowsize/word.h
@@ -45,16 +45,6 @@ forceinline uint64_t MASK(int n) {
   return ~0ull >> (64 - 8 * n);
 }
 
-forceinline uint64_t LOAD(const uint8_t* bytes, int n) {
-  uint64_t x = *(uint64_t*)bytes & MASK(n);
-  return U64TOWORD(x);
-}
-
-forceinline void STORE(uint8_t* bytes, uint64_t w, int n) {
-  *(uint64_t*)bytes &= ~MASK(n);
-  *(uint64_t*)bytes |= WORDTOU64(w);
-}
-
 forceinline uint64_t LOADBYTES(const uint8_t* bytes, int n) {
   uint64_t x = 0;
   memcpy(&x, bytes, n);
@@ -64,6 +54,14 @@ forceinline uint64_t LOADBYTES(const uint8_t* bytes, int n) {
 forceinline void STOREBYTES(uint8_t* bytes, uint64_t w, int n) {
   uint64_t x = WORDTOU64(w);
   memcpy(bytes, &x, n);
+}
+
+forceinline uint64_t LOAD(const uint8_t* bytes, int n) {
+  return LOADBYTES(bytes, n);
+}
+
+forceinline void STORE(uint8_t* bytes, uint64_t w, int n) {
+  STOREBYTES(bytes, w, n);
 }
 
 #endif /* WORD_H_ */

--- a/crypto_aead/ascon128av12/armv7m_small/word.h
+++ b/crypto_aead/ascon128av12/armv7m_small/word.h
@@ -45,16 +45,6 @@ forceinline uint64_t MASK(int n) {
   return ~0ull >> (64 - 8 * n);
 }
 
-forceinline uint64_t LOAD(const uint8_t* bytes, int n) {
-  uint64_t x = *(uint64_t*)bytes & MASK(n);
-  return U64TOWORD(x);
-}
-
-forceinline void STORE(uint8_t* bytes, uint64_t w, int n) {
-  *(uint64_t*)bytes &= ~MASK(n);
-  *(uint64_t*)bytes |= WORDTOU64(w);
-}
-
 forceinline uint64_t LOADBYTES(const uint8_t* bytes, int n) {
   uint64_t x = 0;
   memcpy(&x, bytes, n);
@@ -64,6 +54,14 @@ forceinline uint64_t LOADBYTES(const uint8_t* bytes, int n) {
 forceinline void STOREBYTES(uint8_t* bytes, uint64_t w, int n) {
   uint64_t x = WORDTOU64(w);
   memcpy(bytes, &x, n);
+}
+
+forceinline uint64_t LOAD(const uint8_t* bytes, int n) {
+  return LOADBYTES(bytes, n);
+}
+
+forceinline void STORE(uint8_t* bytes, uint64_t w, int n) {
+  STOREBYTES(bytes, w, n);
 }
 
 #endif /* WORD_H_ */

--- a/crypto_aead/ascon128v12/armv7m/word.h
+++ b/crypto_aead/ascon128v12/armv7m/word.h
@@ -45,16 +45,6 @@ forceinline uint64_t MASK(int n) {
   return ~0ull >> (64 - 8 * n);
 }
 
-forceinline uint64_t LOAD(const uint8_t* bytes, int n) {
-  uint64_t x = *(uint64_t*)bytes & MASK(n);
-  return U64TOWORD(x);
-}
-
-forceinline void STORE(uint8_t* bytes, uint64_t w, int n) {
-  *(uint64_t*)bytes &= ~MASK(n);
-  *(uint64_t*)bytes |= WORDTOU64(w);
-}
-
 forceinline uint64_t LOADBYTES(const uint8_t* bytes, int n) {
   uint64_t x = 0;
   memcpy(&x, bytes, n);
@@ -64,6 +54,14 @@ forceinline uint64_t LOADBYTES(const uint8_t* bytes, int n) {
 forceinline void STOREBYTES(uint8_t* bytes, uint64_t w, int n) {
   uint64_t x = WORDTOU64(w);
   memcpy(bytes, &x, n);
+}
+
+forceinline uint64_t LOAD(const uint8_t* bytes, int n) {
+  return LOADBYTES(bytes, n);
+}
+
+forceinline void STORE(uint8_t* bytes, uint64_t w, int n) {
+  STOREBYTES(bytes, w, n);
 }
 
 #endif /* WORD_H_ */

--- a/crypto_aead/ascon128v12/armv7m_lowsize/aead.c
+++ b/crypto_aead/ascon128v12/armv7m_lowsize/aead.c
@@ -98,8 +98,9 @@ void ascon_aead(uint8_t* t, uint8_t* out, const uint8_t* in, uint64_t tlen,
   if (mode == ASCON_DECRYPT) printstate("pad ciphertext", &s);
   /* finalize */
   ascon_final(&s, &key);
-  ((uint64_t*)t)[0] = WORDTOU64(s.x[3]);
-  ((uint64_t*)t)[1] = WORDTOU64(s.x[4]);
+  /* set tag */
+  STOREBYTES(t, s.x[3], 8);
+  STOREBYTES(t + 8, s.x[4], 8);
 }
 
 #endif

--- a/crypto_aead/ascon128v12/armv7m_lowsize/word.h
+++ b/crypto_aead/ascon128v12/armv7m_lowsize/word.h
@@ -45,16 +45,6 @@ forceinline uint64_t MASK(int n) {
   return ~0ull >> (64 - 8 * n);
 }
 
-forceinline uint64_t LOAD(const uint8_t* bytes, int n) {
-  uint64_t x = *(uint64_t*)bytes & MASK(n);
-  return U64TOWORD(x);
-}
-
-forceinline void STORE(uint8_t* bytes, uint64_t w, int n) {
-  *(uint64_t*)bytes &= ~MASK(n);
-  *(uint64_t*)bytes |= WORDTOU64(w);
-}
-
 forceinline uint64_t LOADBYTES(const uint8_t* bytes, int n) {
   uint64_t x = 0;
   memcpy(&x, bytes, n);
@@ -64,6 +54,14 @@ forceinline uint64_t LOADBYTES(const uint8_t* bytes, int n) {
 forceinline void STOREBYTES(uint8_t* bytes, uint64_t w, int n) {
   uint64_t x = WORDTOU64(w);
   memcpy(bytes, &x, n);
+}
+
+forceinline uint64_t LOAD(const uint8_t* bytes, int n) {
+  return LOADBYTES(bytes, n);
+}
+
+forceinline void STORE(uint8_t* bytes, uint64_t w, int n) {
+  STOREBYTES(bytes, w, n);
 }
 
 #endif /* WORD_H_ */

--- a/crypto_aead/ascon128v12/armv7m_small/word.h
+++ b/crypto_aead/ascon128v12/armv7m_small/word.h
@@ -45,16 +45,6 @@ forceinline uint64_t MASK(int n) {
   return ~0ull >> (64 - 8 * n);
 }
 
-forceinline uint64_t LOAD(const uint8_t* bytes, int n) {
-  uint64_t x = *(uint64_t*)bytes & MASK(n);
-  return U64TOWORD(x);
-}
-
-forceinline void STORE(uint8_t* bytes, uint64_t w, int n) {
-  *(uint64_t*)bytes &= ~MASK(n);
-  *(uint64_t*)bytes |= WORDTOU64(w);
-}
-
 forceinline uint64_t LOADBYTES(const uint8_t* bytes, int n) {
   uint64_t x = 0;
   memcpy(&x, bytes, n);
@@ -64,6 +54,14 @@ forceinline uint64_t LOADBYTES(const uint8_t* bytes, int n) {
 forceinline void STOREBYTES(uint8_t* bytes, uint64_t w, int n) {
   uint64_t x = WORDTOU64(w);
   memcpy(bytes, &x, n);
+}
+
+forceinline uint64_t LOAD(const uint8_t* bytes, int n) {
+  return LOADBYTES(bytes, n);
+}
+
+forceinline void STORE(uint8_t* bytes, uint64_t w, int n) {
+  STOREBYTES(bytes, w, n);
 }
 
 #endif /* WORD_H_ */

--- a/crypto_aead/ascon80pqv12/armv7m/word.h
+++ b/crypto_aead/ascon80pqv12/armv7m/word.h
@@ -45,16 +45,6 @@ forceinline uint64_t MASK(int n) {
   return ~0ull >> (64 - 8 * n);
 }
 
-forceinline uint64_t LOAD(const uint8_t* bytes, int n) {
-  uint64_t x = *(uint64_t*)bytes & MASK(n);
-  return U64TOWORD(x);
-}
-
-forceinline void STORE(uint8_t* bytes, uint64_t w, int n) {
-  *(uint64_t*)bytes &= ~MASK(n);
-  *(uint64_t*)bytes |= WORDTOU64(w);
-}
-
 forceinline uint64_t LOADBYTES(const uint8_t* bytes, int n) {
   uint64_t x = 0;
   memcpy(&x, bytes, n);
@@ -64,6 +54,14 @@ forceinline uint64_t LOADBYTES(const uint8_t* bytes, int n) {
 forceinline void STOREBYTES(uint8_t* bytes, uint64_t w, int n) {
   uint64_t x = WORDTOU64(w);
   memcpy(bytes, &x, n);
+}
+
+forceinline uint64_t LOAD(const uint8_t* bytes, int n) {
+  return LOADBYTES(bytes, n);
+}
+
+forceinline void STORE(uint8_t* bytes, uint64_t w, int n) {
+  STOREBYTES(bytes, w, n);
 }
 
 #endif /* WORD_H_ */

--- a/crypto_aead/ascon80pqv12/armv7m_lowsize/aead.c
+++ b/crypto_aead/ascon80pqv12/armv7m_lowsize/aead.c
@@ -98,8 +98,9 @@ void ascon_aead(uint8_t* t, uint8_t* out, const uint8_t* in, uint64_t tlen,
   if (mode == ASCON_DECRYPT) printstate("pad ciphertext", &s);
   /* finalize */
   ascon_final(&s, &key);
-  ((uint64_t*)t)[0] = WORDTOU64(s.x[3]);
-  ((uint64_t*)t)[1] = WORDTOU64(s.x[4]);
+  /* set tag */
+  STOREBYTES(t, s.x[3], 8);
+  STOREBYTES(t + 8, s.x[4], 8);
 }
 
 #endif

--- a/crypto_aead/ascon80pqv12/armv7m_lowsize/word.h
+++ b/crypto_aead/ascon80pqv12/armv7m_lowsize/word.h
@@ -45,16 +45,6 @@ forceinline uint64_t MASK(int n) {
   return ~0ull >> (64 - 8 * n);
 }
 
-forceinline uint64_t LOAD(const uint8_t* bytes, int n) {
-  uint64_t x = *(uint64_t*)bytes & MASK(n);
-  return U64TOWORD(x);
-}
-
-forceinline void STORE(uint8_t* bytes, uint64_t w, int n) {
-  *(uint64_t*)bytes &= ~MASK(n);
-  *(uint64_t*)bytes |= WORDTOU64(w);
-}
-
 forceinline uint64_t LOADBYTES(const uint8_t* bytes, int n) {
   uint64_t x = 0;
   memcpy(&x, bytes, n);
@@ -64,6 +54,14 @@ forceinline uint64_t LOADBYTES(const uint8_t* bytes, int n) {
 forceinline void STOREBYTES(uint8_t* bytes, uint64_t w, int n) {
   uint64_t x = WORDTOU64(w);
   memcpy(bytes, &x, n);
+}
+
+forceinline uint64_t LOAD(const uint8_t* bytes, int n) {
+  return LOADBYTES(bytes, n);
+}
+
+forceinline void STORE(uint8_t* bytes, uint64_t w, int n) {
+  STOREBYTES(bytes, w, n);
 }
 
 #endif /* WORD_H_ */

--- a/crypto_aead/ascon80pqv12/armv7m_small/word.h
+++ b/crypto_aead/ascon80pqv12/armv7m_small/word.h
@@ -45,16 +45,6 @@ forceinline uint64_t MASK(int n) {
   return ~0ull >> (64 - 8 * n);
 }
 
-forceinline uint64_t LOAD(const uint8_t* bytes, int n) {
-  uint64_t x = *(uint64_t*)bytes & MASK(n);
-  return U64TOWORD(x);
-}
-
-forceinline void STORE(uint8_t* bytes, uint64_t w, int n) {
-  *(uint64_t*)bytes &= ~MASK(n);
-  *(uint64_t*)bytes |= WORDTOU64(w);
-}
-
 forceinline uint64_t LOADBYTES(const uint8_t* bytes, int n) {
   uint64_t x = 0;
   memcpy(&x, bytes, n);
@@ -64,6 +54,14 @@ forceinline uint64_t LOADBYTES(const uint8_t* bytes, int n) {
 forceinline void STOREBYTES(uint8_t* bytes, uint64_t w, int n) {
   uint64_t x = WORDTOU64(w);
   memcpy(bytes, &x, n);
+}
+
+forceinline uint64_t LOAD(const uint8_t* bytes, int n) {
+  return LOADBYTES(bytes, n);
+}
+
+forceinline void STORE(uint8_t* bytes, uint64_t w, int n) {
+  STOREBYTES(bytes, w, n);
 }
 
 #endif /* WORD_H_ */


### PR DESCRIPTION
Fix usage faults triggered by unaligned memory accesses due to casting `uint8_t*`'s to `uint64_t*`. armv7m support unaligned accesses for the `STR` and `LDR` instructions, but not the `STRD` and `LDRD` variants generated by 64 bit memory accesses.

Fixes #13.