### PR TITLE
Securely clear sensitive data after AEAD operations

### DIFF
--- a/src/aead.c
+++ b/src/aead.c
@@ -208,6 +208,9 @@ int ascon_aead_encrypt(uint8_t* t, uint8_t* c, const uint8_t* m, uint64_t mlen,
   ascon_encrypt(&s, c, m, mlen);
   ascon_final(&s, &key);
   ascon_gettag(&s, t);
+  /*clearing sensitive material*/
+  ascon_clean(&s, sizeof s);
+  ascon_clean(&key, sizeof key);
   return 0;
 }
 
@@ -221,7 +224,12 @@ int ascon_aead_decrypt(uint8_t* m, const uint8_t* t, const uint8_t* c,
   ascon_adata(&s, ad, adlen);
   ascon_decrypt(&s, m, c, clen);
   ascon_final(&s, &key);
-  return ascon_verify(&s, t);
+  int result = ascon_verify(&s, t);
+  /*clearing sensitive material*/
+  ascon_clean(&s, sizeof s);
+  ascon_clean(&key, sizeof key);
+  return result;
+  
 }
 
 int crypto_aead_encrypt(unsigned char* c, unsigned long long* clen,

--- a/src/word.h
+++ b/src/word.h
@@ -61,7 +61,7 @@ forceinline void STOREBYTES(uint8_t* bytes, uint64_t w, int n) {
 }
 
 /*
- *overwriting a memory region with zeros. The volatile pointer prevents the
+ * overwriting a memory region with zeros. The volatile pointer prevents the
  * compiler from optimizing the loop away, ensuring that sensitive data is
  * actually cleared.
  */

--- a/src/word.h
+++ b/src/word.h
@@ -60,4 +60,15 @@ forceinline void STOREBYTES(uint8_t* bytes, uint64_t w, int n) {
   memcpy(bytes, &x, n);
 }
 
+/*
+ *overwriting a memory region with zeros. The volatile pointer prevents the
+ * compiler from optimizing the loop away, ensuring that sensitive data is
+ * actually cleared.
+ */
+forceinline void ascon_clean(void* data, size_t len) {
+  volatile uint8_t* p = (volatile uint8_t*)data;
+  while (len--) *p++ = 0;
+}
+
+
 #endif /* WORD_H_ */


### PR DESCRIPTION
Made an ascon_clean helper that securely overwrites memory regions with zeros using a volatile pointer, preventing the compiler from optimizing away the zeroing. The AEAD encrypt and decrypt routines were updated to erase the state and key after operations, reducing the risk of residual secrets lingering in memory. This change improves the security of the implementation by ensuring sensitive material is cleared promptly, mitigating potential memory disclosure and side-channel risks. 

~BR